### PR TITLE
Remove leading # from story ids

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-estimate",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "author": "kleinjm",
   "description": "Async private voting for estimation meetings",
   "main": "index.coffee",

--- a/src/estimate.coffee
+++ b/src/estimate.coffee
@@ -108,7 +108,7 @@ updatePivotalTicket = ({ robot, res, projectId, ticketId, points, room }) ->
 module.exports = (robot) ->
   robot.respond /estimate (.*) as (.*)/i, id: 'estimate.estimate', (res) ->
     # tell the user what they voted for and what the vote is
-    ticketId = res.match[1].trim()
+    ticketId = res.match[1].trim().replace(/^#/, '')
     pointsTrimmed = res.match[2].trim()
     points = Number(pointsTrimmed)
 

--- a/test/estimate-test.coffee
+++ b/test/estimate-test.coffee
@@ -23,6 +23,13 @@ describe 'estimate', ->
           ['hubot', "You've estimated story 1 as 3 points"]
         ]
 
+    it 'strips a leading # from the ticket id, since these often accompany Pivotal IDs', ->
+      @room.user.say('kleinjm', 'hubot estimate #1 as 3').then =>
+        expect(@room.messages).to.eql [
+          ['kleinjm', 'hubot estimate #1 as 3']
+          ['hubot', "You've estimated story 1 as 3 points"]
+        ]
+
     it 'outputs verification for 0', ->
       @room.user.say('kleinjm', 'hubot estimate 1 as 0').then =>
         expect(@room.lastMessage()).to.eql(


### PR DESCRIPTION
When copying from Pivotal, it's easy/common to copy the # with the story ID. The estimate bot should be able to handle either format, with or without the #.

    me>    estimate #12345 as 5
    hubot> You've estimated story 12345 as 5 points

    me>    estimate 12345 as 5
    hubot> You've estimated story 12345 as 5 points

Fixes #19