### PR TITLE
Combine median-vote and PT-updated messages for better threading

### DIFF
--- a/src/estimate.coffee
+++ b/src/estimate.coffee
@@ -88,16 +88,18 @@ estimateFor = ({ robot, res, ticketId, room }) ->
   else
     msg = "Median vote of #{median(ticket)} by #{listVoters(ticket, true)}"
 
-  if room then robot.messageRoom(room, msg) else res.send msg
-
   # post to pivotal tracker
   projectId = team?.projectId
   if HUBOT_PIVOTAL_TOKEN? && projectId?
+    messagePrefix = msg
     updatePivotalTicket({
-      robot, res, projectId, ticketId, points: median(ticket), room
+      robot, res, projectId, ticketId, points: median(ticket), room, messagePrefix
     })
+  else
+    if room then robot.messageRoom(room, msg) else res.send msg
 
-updatePivotalTicket = ({ robot, res, projectId, ticketId, points, room }) ->
+
+updatePivotalTicket = ({ robot, res, projectId, ticketId, points, room, messagePrefix }) ->
   data = JSON.stringify { estimate: points }
   url = "#{TRACKER_BASE_URL}/projects/#{projectId}/stories/#{ticketId}"
   storyUrl = "https://www.pivotaltracker.com/story/show/#{ticketId}"
@@ -117,6 +119,7 @@ updatePivotalTicket = ({ robot, res, projectId, ticketId, points, room }) ->
           ticketName = response.name
           msg = "Updated \"#{ticketName}\" with #{points} point(s)\n#{storyUrl}"
 
+        msg = "#{messagePrefix}\n\n#{msg}" if messagePrefix?.length
         if room then robot.messageRoom(room, msg) else res.send msg
 
 module.exports = (robot) ->


### PR DESCRIPTION
Right now, hubot will send two separate messages when a vote is cast:

> Median vote of 2 by person1: 3, person2: 2, person3: 2

followed by

> Updated "Story" with 2 point(s) https://www.pivotaltracker.com/story/show/[id]

Then when we start a Slack thread to discuss, whichever message we start it on lacks context.

Testing
---

The Pivotal Tracker integration is not covered in the test suite. Is this straightforward to test in a staging environment before releasing?